### PR TITLE
Add geocoding enrichment

### DIFF
--- a/audumbla.gemspec
+++ b/audumbla.gemspec
@@ -21,7 +21,10 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'dpla-map', '~>4.0.0.0.pre.10'
+  s.add_dependency 'twofishes'
+  s.add_dependency 'geokit'
 
   s.add_development_dependency 'rspec', '~>3.0'
+  s.add_development_dependency 'webmock'
   s.add_development_dependency 'pry', '>= 0.10.0'
 end

--- a/geocode.yml
+++ b/geocode.yml
@@ -1,0 +1,7 @@
+---
+'distance_threshold': 100
+'max_intepretations': 5
+'twofishes_host': 'localhost'
+'twofishes_port': 8080
+'twofishes_timeout': 10
+'twofishes_retries': 2

--- a/lib/audumbla.rb
+++ b/lib/audumbla.rb
@@ -1,4 +1,8 @@
 module Audumbla
   autoload :Enrichment, 'audumbla/enrichment'
   autoload :FieldEnrichment, 'audumbla/field_enrichment'
+
+  module Enrichments
+    autoload :CoarseGeocode, 'audumbla/enrichments/coarse_geocode'
+  end
 end

--- a/lib/audumbla/enrichments.rb
+++ b/lib/audumbla/enrichments.rb
@@ -1,4 +1,1 @@
-module Audumbla
-  module Enrichments
-  end
-end
+

--- a/lib/audumbla/enrichments/coarse_geocode.rb
+++ b/lib/audumbla/enrichments/coarse_geocode.rb
@@ -1,0 +1,203 @@
+require 'twofishes'
+require 'geokit'
+
+module Audumbla::Enrichments
+  ##
+  # Enriches a `DPLA::MAP::Place` node by running its data through external 
+  # geocoders, using heuristics to determine a matching feature from GeoNames,
+  # and repopulating the `Place` with related data.
+  #
+  # If the existing `Place` contains data other than a `providedLabel`, that 
+  # data will be used as context for evaluating interpretations. For example: 
+  # a `Place` with an existing latitude and longitude will verify that the
+  # point is within the bounding box for a candidate match.
+  # 
+  # `skos:exactMatch` are reserved for the GeoNames features returned by the 
+  # geocoder. Other matching URIs (currently: LC authorities) are included as
+  # `skos:closeMatch`
+  #
+  # @example enriching from a `#providedLabel`
+  #   
+  #    place = DPLA::MAP::Place.new.tap { |p| p.providedLabel = 'Georgia' }
+  #    CoarseGeocode.new.enrich_value.dump :ttl
+  #    # [
+  #    #    a <http://www.europeana.eu/schemas/edm/Place>;
+  #    #    <http://dp.la/about/map/providedLabel> "Georgia";
+  #    #    <http://www.geonames.org/ontology#countryCode> "US";
+  #    #    <http://www.w3.org/2003/01/geo/wgs84_pos#lat> 3.275042e1;
+  #    #    <http://www.w3.org/2003/01/geo/wgs84_pos#long> -8.350018e1;
+  #    #    <http://www.w3.org/2004/02/skos/core#closeMatch> <http://id.loc.gov/authorities/names/n79023113>;
+  #    #    <http://www.w3.org/2004/02/skos/core#exactMatch> <http://sws.geonames.org/4197000/>;
+  #    #    <http://www.w3.org/2004/02/skos/core#prefLabel> "Georgia, United States"
+  #    # ] .
+  #
+  # @example enriching from a `#providedLabel` with lat/lng guidance
+  #   
+  #    place = DPLA::MAP::Place.new.tap do |p| 
+  #      p.providedLabel = 'Georgia'
+  #      p.lat = 41.9997
+  #      p.long = 43.4998
+  #    end
+  #    
+  #    CoarseGeocode.new.enrich_value.dump :ttl
+  #    # [
+  #    #    a <http://www.europeana.eu/schemas/edm/Place>;
+  #    #    <http://dp.la/about/map/providedLabel> "Georgia";
+  #    #    <http://www.geonames.org/ontology#countryCode> "GE";
+  #    #    <http://www.w3.org/2003/01/geo/wgs84_pos#lat> 4.199998e1;
+  #    #    <http://www.w3.org/2003/01/geo/wgs84_pos#long> 4.34999e1;
+  #    #    <http://www.w3.org/2004/02/skos/core#exactMatch> <http://sws.geonames.org/614540/>;
+  #    #    <http://www.w3.org/2004/02/skos/core#prefLabel> "Georgia"
+  #    # ] .
+  #
+  class CoarseGeocode
+    include Audumbla::FieldEnrichment
+
+    DEFAULT_DISTANCE_THRESHOLD_KMS = 100
+
+    Twofishes.configure do |config|
+      config.host = 'localhost' 
+      config.port = 8080
+      config.timeout = 100
+      config.retries = 2 
+    end
+
+    ##
+    # Enriches the given value against the TwoFishes coarse geocoder. This 
+    # process adds a `skos:exactMatch` for a matching GeoNames URI, if any, and
+    # populates the remaining place data to the degree possible from the matched
+    # feature.
+    # 
+    # @param [DPLA::MAP::Place] value  the place to geocode
+    #
+    # @return [DPLA::MAP::Place] the inital place, enriched via coarse geocoding
+    def enrich_value(value)
+      return value unless value.is_a? DPLA::MAP::Place
+      interpretations = geocode(value.providedLabel.first, 
+                                [],
+                                maxInterpretations: 5)
+      match = interpretations.find { |interp| match?(interp, value) }
+      match.nil? ? value : enrich_place(value, match.feature)
+    end
+
+    ##
+    # Checks that we are satisfied with the geocoder's best matches prior to 
+    # acceptance. Most tweaks to the geocoding process should be taken care
+    # of at the geocoder itself, but a simple accept/reject of the points 
+    # offered is possible here. This allows existing data about the place
+    # to be used as context.
+    #
+    # For example, this method returns false if `place` contains latitude
+    # and longitude, but the candidate match has a geometry far away from those
+    # given.
+    #
+    # @param [GeocodeInterpretation] interpretation  a twofishes interpretation
+    # @param [#lat#long] place  a place to verify a match against
+    #
+    # @result [Boolean] true if the interpretation is accepted
+    def match?(interpretation, place)
+      return true if place.lat.empty? || place.long.empty?
+
+      point = Geokit::LatLng.new(place.lat.first, place.long.first)
+      if interpretation.geometry.bounds.nil?
+        # measure distance between point centers
+        distance = twofishes_point_to_geokit(interpretation.geometry.center)
+                   .distance_to(point, unit: :kms)
+        return distance < DEFAULT_DISTANCE_THRESHOLD_KMS
+      end
+        
+      twofishes_bounds_to_geokit(interpretation.geometry.bounds)
+        .contains?(point)
+    end
+
+    private
+
+    ##
+    # Populates a DPLA::MAP::Place with data from a given feature. This 
+    # overwrites existing data with the exception of the identity (URI or node 
+    # id) and the `providedLabel`. `exactMatch`, `closeMatch`, `label` 
+    # (skos:prefLabel)and all other geographic data is replaced.
+    # 
+    # @param [DPLA::MAP::Place] place  a place to enrich
+    # @param [GeocodeFeature] feature  a twofishes feature whose data should be
+    #   added to place.
+    #
+    # @return [DPLA::MAP::Place] the original place enriched
+    def enrich_place(place, feature)
+      place.label = feature.display_name
+      place.exactMatch = feature_to_geoname_uris(feature)
+      place.closeMatch = feature_to_close_matches(feature, 
+                                                  /^http\:\/\/id\.loc\.gov\/.*/)
+      place.countryCode = feature.cc
+      place.lat = feature.geometry.center.lat
+      place.long = feature.geometry.center.lng
+
+      place
+    end
+
+    ##
+    # Extracts geonameids for the given feature and converts them into URIs
+    #
+    # @param [GeocodeFeature] feature the feature to identify
+    #
+    # @return [Array<RDF::URI>] a list of geoname URIs. Generally, this will only 
+    #   contain one exactly matching geonameid in URI form.
+    def feature_to_geoname_uris(feature)
+      geoname_ids = feature.ids.select { |id| id.source == :geonameid.to_s }
+      geoname_ids.map { |id| RDF::URI('http://sws.geonames.org') / id.id + '/' }
+    end
+
+    ##
+    # Extracts URIs for closely matching terms in other authority or knowledege
+    # organization systems
+    #
+    # @param [GeocodeFeature] feature the feature to identify
+    # @param [Regexp] patterns a splat argument containing any number of 
+    #   patterns matching
+    #
+    # @return [Array<RDF::URI>] a list of matching ids
+    def feature_to_close_matches(feature, *patterns)
+      union = Regexp.union(patterns)
+      feature.attributes.urls.select { |str| union.match(str) }
+        .map { |id| RDF::URI(id) }
+    end
+    
+    ##
+    # Sends a geocode request. This is used in lieu of `Twofishes#geocode`, 
+    # since that method does not allow passing parameters other than 
+    # `responseIncludes`.
+    #
+    # @param [#to_s] location  the string to try to match
+    # @param [Array] includes  a list of twofishes include constants
+    # @param [Hash<Symbol, #to_s> params  property and value pairs for 
+    #   parameters to pass to the request
+    #
+    # @see Twofishes#geocode
+    # @see Twofishes::Client
+    def geocode(location, includes = [], params = {})
+      client = Twofishes::Client
+      client.send(:handle_response) do
+        request = GeocodeRequest.new(query: location, responseIncludes: includes)
+        params.each { |prop, val| request.send("#{prop}=".to_sym, val) }
+        client.thrift_client.geocode(request)
+      end
+    end
+
+    ##
+    # @param [#lat#long] point  a twofishes point to convert to Geokit
+    #
+    # @return [Geokit::LatLng]
+    def twofishes_point_to_geokit(point)
+      Geokit::LatLng.new(point.lat, point.lng)
+    end
+
+    ##
+    # @param [#ne#sw] bounds  a twofishes binding box to convert to Geokit
+    #
+    # @return [Geokit::Bounds]
+    def twofishes_bounds_to_geokit(bounds)
+      Geokit::Bounds.new(twofishes_point_to_geokit(bounds.sw), 
+                         twofishes_point_to_geokit(bounds.ne))
+    end
+  end
+end

--- a/lib/audumbla/field_enrichment.rb
+++ b/lib/audumbla/field_enrichment.rb
@@ -42,7 +42,19 @@ module Audumbla
       return record unless record.respond_to? field
       values = record.send(field)
       if field_chain.length == 1
-        new_values = values.map { |v| enrich_value(v) }.flatten.compact
+        new_values = values.map { |v| enrich_value(v) }
+        # We call #flatten twice, since under some circumstances it fails on 
+        # nested #to_ary calls the first time. This appears to be related to:
+        #
+        # http://yehudakatz.com/2010/01/02/the-craziest-fing-bug-ive-ever-seen/
+        #   and
+        # https://bugs.ruby-lang.org/issues/2494
+        begin
+          new_values = new_values.flatten.compact
+        rescue
+          new_values = new_values.flatten.compact
+        end
+
         record.send("#{field}=".to_sym, new_values)
       else
         resources(values).each { |v| enrich_field(v, field_chain[1..-1]) }

--- a/spec/fixtures/georgia.yml
+++ b/spec/fixtures/georgia.yml
@@ -1,0 +1,276 @@
+--- !ruby/object:GeocodeResponse
+interpretations:
+- !ruby/object:GeocodeInterpretation
+  what: ''
+  where: georgia
+  feature: !ruby/object:GeocodeFeature
+    woeType: 8
+    cc: US
+    geometry: !ruby/object:FeatureGeometry
+      center: !ruby/object:GeocodePoint
+        lat: 32.75042
+        lng: -83.50018
+      bounds: !ruby/object:GeocodeBoundingBox
+        ne: !ruby/object:GeocodePoint
+          lat: 35.000659
+          lng: -80.751429
+        sw: !ruby/object:GeocodePoint
+          lat: 30.355756999999997
+          lng: -85.605165
+      source: usa_adm1.shp
+    name: Georgia
+    displayName: Georgia, United States
+    ids:
+    - !ruby/object:FeatureId
+      source: geonameid
+      id: '4197000'
+    - !ruby/object:FeatureId
+      source: woeid
+      id: '2347569'
+    names:
+    - !ruby/object:FeatureName
+      flags:
+      - 2
+      name: GA
+      lang: abbr
+    - !ruby/object:FeatureName
+      flags:
+      - 16
+      name: State of Georgia
+      lang: en
+    - !ruby/object:FeatureName
+      flags:
+      - 64
+      - 16
+      name: Peach State
+      lang: en
+    - !ruby/object:FeatureName
+      flags:
+      - 128
+      - 16
+      - 1
+      name: Georgia
+      lang: en
+    highlightedName: "<b>Georgia</b>, United States"
+    matchedName: Georgia, United States
+    id: geonameid:4197000
+    attributes: !ruby/object:GeocodeFeatureAttributes
+      adm0cap: false
+      adm1cap: false
+      scalerank: 20
+      labelrank: 0
+      natscale: 0
+      population: 8975842
+      sociallyRelevant: false
+      worldcity: false
+      urls:
+      - http://id.loc.gov/authorities/names/n79023113
+      - http://en.wikipedia.org/wiki/Georgia_(U.S._state)
+    longId: 72057594042124936
+    parentIds:
+    - 72057594044179937
+- !ruby/object:GeocodeInterpretation
+  what: ''
+  where: georgia
+  feature: !ruby/object:GeocodeFeature
+    woeType: 12
+    cc: GE
+    geometry: !ruby/object:FeatureGeometry
+      center: !ruby/object:GeocodePoint
+        lat: 41.99998
+        lng: 43.4999
+      bounds: !ruby/object:GeocodeBoundingBox
+        ne: !ruby/object:GeocodePoint
+          lat: 43.586627
+          lng: 46.736119
+        sw: !ruby/object:GeocodePoint
+          lat: 41.054942
+          lng: 40.006604
+      source: gn-adm0-new3.json
+    name: Georgia
+    displayName: Georgia
+    ids:
+    - !ruby/object:FeatureId
+      source: geonameid
+      id: '614540'
+    names:
+    - !ruby/object:FeatureName
+      flags:
+      - 2
+      name: GE
+      lang: abbr
+    - !ruby/object:FeatureName
+      flags:
+      - 1024
+      name: Georgian Soviet Socialist Republic
+      lang: en
+    - !ruby/object:FeatureName
+      flags:
+      - 128
+      - 64
+      - 1
+      name: Georgia
+      lang: en
+    highlightedName: "<b>Georgia</b>"
+    matchedName: Georgia
+    id: geonameid:614540
+    attributes: !ruby/object:GeocodeFeatureAttributes
+      adm0cap: false
+      adm1cap: false
+      scalerank: 20
+      labelrank: 0
+      natscale: 0
+      population: 4630000
+      sociallyRelevant: false
+      worldcity: false
+      urls:
+      - http://ru.wikipedia.org/wiki/%D0%93%D1%80%D1%83%D0%B7%D0%B8%D1%8F
+      - http://en.wikipedia.org/wiki/Georgia_%28country%29
+    longId: 72057594038542476
+    parentIds:
+    - 72057594044183083
+    longIds:
+    - 72057594038542363
+- !ruby/object:GeocodeInterpretation
+  what: ''
+  where: georgia
+  feature: !ruby/object:GeocodeFeature
+    woeType: 10
+    cc: US
+    geometry: !ruby/object:FeatureGeometry
+      center: !ruby/object:GeocodePoint
+        lat: 44.72824
+        lng: -73.12763
+    name: Town of Georgia
+    displayName: Town of Georgia, VT, United States
+    ids:
+    - !ruby/object:FeatureId
+      source: geonameid
+      id: '5236379'
+    - !ruby/object:FeatureId
+      source: woeid
+      id: '2409718'
+    names:
+    - !ruby/object:FeatureName
+      flags:
+      - 16
+      - 1
+      name: Town of Georgia
+      lang: en
+    - !ruby/object:FeatureName
+      flags:
+      - 16
+      - 8
+      - 1
+      name: Georgia
+      lang: en
+    highlightedName: "<b>Georgia</b>, VT, United States"
+    matchedName: Georgia, VT, United States
+    id: geonameid:5236379
+    attributes: !ruby/object:GeocodeFeatureAttributes
+      adm0cap: false
+      adm1cap: false
+      scalerank: 20
+      labelrank: 0
+      natscale: 0
+      population: 0
+      sociallyRelevant: false
+      worldcity: false
+      urls: []
+    longId: 72057594043164315
+    parentIds:
+    - 72057594044179937
+    - 72057594043170219
+    - 72057594043164215
+- !ruby/object:GeocodeInterpretation
+  what: ''
+  where: georgia
+  feature: !ruby/object:GeocodeFeature
+    woeType: 7
+    cc: US
+    geometry: !ruby/object:FeatureGeometry
+      center: !ruby/object:GeocodePoint
+        lat: 40.18733
+        lng: -74.28459
+      bounds: !ruby/object:GeocodeBoundingBox
+        ne: !ruby/object:GeocodePoint
+          lat: 40.1990013123
+          lng: -74.2533340454
+        sw: !ruby/object:GeocodePoint
+          lat: 40.1450004578
+          lng: -74.3127212524
+    name: Georgia
+    displayName: Georgia, NJ, United States
+    ids:
+    - !ruby/object:FeatureId
+      source: geonameid
+      id: '5098392'
+    - !ruby/object:FeatureId
+      source: woeid
+      id: '2409714'
+    names:
+    - !ruby/object:FeatureName
+      flags:
+      - 16
+      - 1
+      name: Georgia
+      lang: en
+    highlightedName: "<b>Georgia</b>, NJ, United States"
+    matchedName: Georgia, NJ, United States
+    id: geonameid:5098392
+    attributes: !ruby/object:GeocodeFeatureAttributes
+      adm0cap: false
+      adm1cap: false
+      scalerank: 20
+      labelrank: 0
+      natscale: 0
+      population: 0
+      sociallyRelevant: false
+      worldcity: false
+      urls:
+      - http://en.wikipedia.org/wiki/Georgia%2C_New_Jersey
+    longId: 72057594043026328
+    parentIds:
+    - 72057594044179937
+    - 72057594043029696
+    - 72057594043029241
+- !ruby/object:GeocodeInterpretation
+  what: ''
+  where: georgia
+  feature: !ruby/object:GeocodeFeature
+    woeType: 0
+    cc: CM
+    geometry: !ruby/object:FeatureGeometry
+      center: !ruby/object:GeocodePoint
+        lat: 6.6
+        lng: 14.01667
+    name: Gorgia
+    displayName: Gorgia, Cameroon
+    ids:
+    - !ruby/object:FeatureId
+      source: geonameid
+      id: '2231063'
+    names:
+    - !ruby/object:FeatureName
+      flags:
+      - 16
+      - 1
+      name: Gorgia
+      lang: en
+    highlightedName: "<b>Georgia</b>, Cameroon"
+    matchedName: Georgia, Cameroon
+    id: geonameid:2231063
+    attributes: !ruby/object:GeocodeFeatureAttributes
+      adm0cap: false
+      adm1cap: false
+      scalerank: 20
+      labelrank: 0
+      natscale: 0
+      population: 0
+      sociallyRelevant: false
+      worldcity: false
+      urls: []
+    longId: 72057594040158999
+    parentIds:
+    - 72057594040161323
+    - 72057594040163951

--- a/spec/lib/audumbla/enrichments/coarse_geocode_spec.rb
+++ b/spec/lib/audumbla/enrichments/coarse_geocode_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Audumbla::Enrichments::CoarseGeocode do
+  it_behaves_like 'a field enrichment'
+
+  describe '#enrich_value' do
+    let(:place) do
+      build(:place,
+            providedLabel: 'georgia',
+            label: nil,
+            exactMatch: nil,            
+            countryCode: nil,
+            parentFeature: nil,
+            lat: nil,
+            long: nil,
+            alt: nil)
+    end
+
+    let(:prefLabel) { 'Georgia, United States' }
+    let(:geoname_uri) { RDF::URI('http://sws.geonames.org/4197000/') }
+    let(:country_code) { 'US' }
+    let(:lat) { 32.75042 }
+    let(:lng) { -83.50018 }
+    let(:lcname_uri) do
+      RDF::URI('http://id.loc.gov/authorities/names/n79023113')
+    end
+
+    before { WebMock.disable_net_connect! }
+
+    it 'returns the same place entity' do
+      expect(subject.enrich_value(place)).to eq place
+    end
+
+    it 'retains providedLabel' do
+      expect(subject.enrich_value(place))
+        .to have_attributes(providedLabel: contain_exactly('georgia'))
+    end
+
+    it 'it gives the geoname as skos:exactMatch' do
+      expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+        .to contain_exactly(geoname_uri)
+    end
+
+    it 'adds LC closeMatches, if appropriate' do
+      expect(subject.enrich_value(place).closeMatch.map(&:rdf_subject))
+        .to contain_exactly(lcname_uri)
+    end
+
+    it 'enriches place with new data' do
+      expect(subject.enrich_value(place))
+        .to have_attributes(
+              label: contain_exactly(prefLabel),
+              countryCode: contain_exactly(country_code),
+              lat: contain_exactly(be_within(0.01).of(lat)),
+              long: contain_exactly(be_within(0.01).of(lng))
+            )
+    end
+
+    context 'with lat/lng' do
+      context 'and label' do
+        let(:place) do
+          build(:place,
+                providedLabel: 'georgia',
+                label: nil,
+                exactMatch: nil,            
+                countryCode: nil,
+                parentFeature: nil,
+                lat: lat,
+                long: lng,
+                alt: nil)
+        end
+
+        it 'gives result matching lat/lng' do
+          expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+            .to contain_exactly(geoname_uri)
+        end
+
+        it 'skips result not matching lat/lng' do
+          place.lat = 41.9997
+          place.long = 43.4998
+
+          georgia_country_uri = RDF::URI('http://sws.geonames.org/614540/')
+
+          # points are in bounding box for Georgia but not equal to center
+          expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+            .to contain_exactly(georgia_country_uri)
+        end
+
+        it 'selects no match if none match lat/lng' do
+          place.lat = 41.9997
+          place.long = -43.4998
+          expect(subject.enrich_value(place).exactMatch).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/audumbla/enrichments/coarse_geocode_spec.rb
+++ b/spec/lib/audumbla/enrichments/coarse_geocode_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 describe Audumbla::Enrichments::CoarseGeocode do
   it_behaves_like 'a field enrichment'
 
+  before do
+    allow(Twofishes::Client)
+      .to receive(:handle_response)
+           .and_return(Twofishes::Result.from_response(georgia_response))
+  end
+
+  let(:georgia_response) { YAML::load_file('spec/fixtures/georgia.yml') }
+
   describe '#enrich_value' do
     let(:place) do
       build(:place,
@@ -25,71 +33,71 @@ describe Audumbla::Enrichments::CoarseGeocode do
       RDF::URI('http://id.loc.gov/authorities/names/n79023113')
     end
 
-    before { WebMock.disable_net_connect! }
+    describe '#enrich_value' do
+      it 'returns the same place entity' do
+        expect(subject.enrich_value(place)).to eq place
+      end
 
-    it 'returns the same place entity' do
-      expect(subject.enrich_value(place)).to eq place
-    end
+      it 'retains providedLabel' do
+        expect(subject.enrich_value(place))
+          .to have_attributes(providedLabel: contain_exactly('georgia'))
+      end
 
-    it 'retains providedLabel' do
-      expect(subject.enrich_value(place))
-        .to have_attributes(providedLabel: contain_exactly('georgia'))
-    end
+      it 'it gives the geoname as skos:exactMatch' do
+        expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+          .to contain_exactly(geoname_uri)
+      end
 
-    it 'it gives the geoname as skos:exactMatch' do
-      expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
-        .to contain_exactly(geoname_uri)
-    end
+      it 'adds LC closeMatches, if appropriate' do
+        expect(subject.enrich_value(place).closeMatch.map(&:rdf_subject))
+          .to contain_exactly(lcname_uri)
+      end
 
-    it 'adds LC closeMatches, if appropriate' do
-      expect(subject.enrich_value(place).closeMatch.map(&:rdf_subject))
-        .to contain_exactly(lcname_uri)
-    end
+      it 'enriches place with new data' do
+        expect(subject.enrich_value(place))
+          .to have_attributes(
+                label: contain_exactly(prefLabel),
+                countryCode: contain_exactly(country_code),
+                lat: contain_exactly(be_within(0.01).of(lat)),
+                long: contain_exactly(be_within(0.01).of(lng))
+              )
+      end
 
-    it 'enriches place with new data' do
-      expect(subject.enrich_value(place))
-        .to have_attributes(
-              label: contain_exactly(prefLabel),
-              countryCode: contain_exactly(country_code),
-              lat: contain_exactly(be_within(0.01).of(lat)),
-              long: contain_exactly(be_within(0.01).of(lng))
-            )
-    end
+      context 'with lat/lng' do
+        context 'and label' do
+          let(:place) do
+            build(:place,
+                  providedLabel: 'georgia',
+                  label: nil,
+                  exactMatch: nil,            
+                  countryCode: nil,
+                  parentFeature: nil,
+                  lat: lat,
+                  long: lng,
+                  alt: nil)
+          end
 
-    context 'with lat/lng' do
-      context 'and label' do
-        let(:place) do
-          build(:place,
-                providedLabel: 'georgia',
-                label: nil,
-                exactMatch: nil,            
-                countryCode: nil,
-                parentFeature: nil,
-                lat: lat,
-                long: lng,
-                alt: nil)
-        end
+          it 'gives result matching lat/lng' do
+            expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+              .to contain_exactly(geoname_uri)
+          end
 
-        it 'gives result matching lat/lng' do
-          expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
-            .to contain_exactly(geoname_uri)
-        end
+          it 'skips result not matching lat/lng' do
+            place.lat = 41.9997
+            place.long = 43.4998
 
-        it 'skips result not matching lat/lng' do
-          place.lat = 41.9997
-          place.long = 43.4998
+            georgia_country_uri = RDF::URI('http://sws.geonames.org/614540/')
 
-          georgia_country_uri = RDF::URI('http://sws.geonames.org/614540/')
+            # points are in bounding box for Georgia but not equal to center
+            expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
+              .to contain_exactly(georgia_country_uri)
+          end
 
-          # points are in bounding box for Georgia but not equal to center
-          expect(subject.enrich_value(place).exactMatch.map(&:rdf_subject))
-            .to contain_exactly(georgia_country_uri)
-        end
-
-        it 'selects no match if none match lat/lng' do
-          place.lat = 41.9997
-          place.long = -43.4998
-          expect(subject.enrich_value(place).exactMatch).to be_empty
+          it 'selects no match if none match lat/lng' do
+            place.lat = 41.9997
+            place.long = -43.4998
+            expect(subject.enrich_value(place).exactMatch).to be_empty
+          end
         end
       end
     end


### PR DESCRIPTION
This has two remaining requirements before it's ready to go:

  - The test suite does not currently run independently. It requires a running twofishes. I think the best approach is to stub out all the web requests. Webmock is installed for this purpose, but not currently working.
  - We need Automation tasks to get twofishes up in production; and possibly we need to do more work to plan where we will host similar external services for other enrichments.

Note also the changes from: https://github.com/dpla/audumbla/compare/feature/geocode?expand=1#diff-bd0c51c8d1d7aa8175be83499a22f6c5R46

I'm not sure why this enrichment runs up against this bug, but if we can resolve it, we should.